### PR TITLE
Make memoized functions documentable

### DIFF
--- a/src/Memoize.jl
+++ b/src/Memoize.jl
@@ -106,7 +106,7 @@ macro memoize(args...)
     esc(quote
         $ex
         empty!($fcache)
-        $f($(args...),)::$rettype =
+        Base.@__doc__ $f($(args...),)::$rettype =
             haskey($fcache, ($(tup...),)) ? $lookup :
             ($fcache[($(tup...),)] = $u($(identargs...),))
     end)


### PR DESCRIPTION
Hi, I'm loving the Memoize.jl package and I'm using it for one of my projects.

When writing the documentation, I came across this error:
`'@memoize' not documentable. See 'Base.@__doc__' docs for details.`

So I googled around and found [this](https://docs.julialang.org/en/stable/manual/documentation/#Core.@__doc__) in the julia docs.

This PR makes memoized functins documentable.