### PR TITLE
Update package uuid to match General registry

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,5 @@
 name = "Memoize"
-uuid = "0fb7230c-a6dd-11e8-35c5-25eda89965fd"
+uuid = "c03570c3-d221-55d1-a50c-7939bbd78826"
 authors = ["Simon Kornblith <simon@simonster.com>"]
 version = "0.3.0"
 


### PR DESCRIPTION
Closes #41

* Not sure why this doesn't match.  From the commit history, the current
  uuid has been there for 3 years, and the uuid in the general registry 
  has been there for about as long.