### PR TITLE
RFC: Allow dict parameter to be a function call

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,38 @@ using Memoize
 	a
 end
 ```
+
+You can also specify the full function call for constructing the dictionary.  For example, to use LRUCache.jl:
+
+```julia
+using Memoize
+using LRUCache
+@memoize LRU{Tuple{Any,Any},Any}(maxsize=2) function x(a, b)
+    println("Running")
+    a + b
+end
+```
+
+```julia
+julia> x(1,2)
+Running
+3
+
+julia> x(1,2)
+3
+
+julia> x(2,2)
+Running
+4
+
+julia> x(2,3)
+Running
+5
+
+julia> x(1,2)
+Running
+3
+
+julia> x(2,3)
+5
+```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -319,3 +319,17 @@ end
 @test run == 2
 
 end
+
+run = 0
+@memoize Dict{Tuple{String},Int}() function dict_call(a::String)::Int
+    global run += 1
+    length(a)
+end
+@test dict_call("a") == 1
+@test run == 1
+@test dict_call("a") == 1
+@test run == 1
+@test dict_call("bb") == 2
+@test run == 2
+@test dict_call("bb") == 2
+@test run == 2


### PR DESCRIPTION
* For example, this would let one use `LRUCache.LRU` as the cache

```julia
julia> @memoize LRU{Tuple{Any,Any},Any}(maxsize=2) function x(a, b)
           println("Running")
           a + b
       end
```

Partially addresses #37.  As can be seen above, the specific invocation for using LRUCache is a bit verbose/awkward, so we may want to do something nicer/smarter.

Cc: @cstjean @tk3369 @djsegal