### PR TITLE
Handle Vararg type in functions

### DIFF
--- a/src/Memoize.jl
+++ b/src/Memoize.jl
@@ -1,5 +1,5 @@
 module Memoize
-using MacroTools: splitdef, combinedef, splitarg
+using MacroTools: combinedef, namify, splitarg, splitdef
 export @memoize
 
 macro memoize(args...)
@@ -31,7 +31,7 @@ macro memoize(args...)
     # Set up identity arguments to pass to unmemoized function
     identargs = map(args) do arg
         arg_name, typ, slurp, default = splitarg(arg)
-        if slurp
+        if slurp || namify(typ) === :Vararg
             Expr(:..., arg_name)
         else
             arg_name

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -281,6 +281,20 @@ end
 @test documented_function(2) == 2
 @test run == 2
 
+run = 0
+@memoize function vararg_func(list::Vararg{Tuple{Int64,Int64}})
+    global run += 1
+    return list[1]
+end
+@test vararg_func((1,1), (1,1)) == (1,1)
+@test run == 1
+@test vararg_func((1,1), (1,1)) == (1,1)
+@test run == 1
+@test vararg_func((1,1), (1,2)) == (1,1)
+@test run == 2
+@test vararg_func((1,1), (1,2)) == (1,1)
+@test run == 2
+
 
 module MemoizeTest
 using Test
@@ -305,4 +319,3 @@ end
 @test run == 2
 
 end
-


### PR DESCRIPTION
* The corresponding variable needs to be splatted when calling the
  unmemoized function

Fixes #26 