### PR TITLE
Add clear-cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
   - linux
   - osx
 julia:
-  - 1.1
+  - 1.2
   - 1.5
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -10,27 +10,31 @@ Easy memoization for Julia.
 using Memoize
 @memoize function x(a)
 	println("Running")
-	a
+	2a
 end
 ```
 
 ```
 julia> x(1)
 Running
-1
+2
+
+julia> @memoize_cache(x)
+IdDict{Any,Any} with 1 entry:
+  (1,) => 2
 
 julia> x(1)
-1
+2
 
-julia> @clear_cache(x)
+julia> empty!(@memoize_cache(x))
 IdDict{Any,Any}()
 
 julia> x(1)
 Running
-1
+2
 
 julia> x(1)
-1
+2
 ```
 
 By default, Memoize.jl uses an [`IdDict`](https://docs.julialang.org/en/v1/base/collections/#Base.IdDict) as a cache, but it's also possible to specify the type of the cache. If you want to cache vectors based on the values they contain, you probably want this:

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ julia> x(1)
 Running
 2
 
-julia> @memoize_cache(x)
+julia> memoize_cache(x)
 IdDict{Any,Any} with 1 entry:
   (1,) => 2
 
 julia> x(1)
 2
 
-julia> empty!(@memoize_cache(x))
+julia> empty!(memoize_cache(x))
 IdDict{Any,Any}()
 
 julia> x(1)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ Running
 
 julia> x(1)
 1
+
+julia> @clear_cache(x)
+IdDict{Any,Any}()
+
+julia> x(1)
+Running
+1
+
+julia> x(1)
+1
 ```
 
 By default, Memoize.jl uses an [`IdDict`](https://docs.julialang.org/en/v1/base/collections/#Base.IdDict) as a cache, but it's also possible to specify the type of the cache. If you want to cache vectors based on the values they contain, you probably want this:
@@ -33,7 +43,7 @@ using Memoize
 end
 ```
 
-You can also specify the full function call for constructing the dictionary.  For example, to use LRUCache.jl:
+You can also specify the full function call for constructing the dictionary. For example, to use LRUCache.jl:
 
 ```julia
 using Memoize

--- a/src/Memoize.jl
+++ b/src/Memoize.jl
@@ -80,7 +80,7 @@ end
 macro clear_cache(f)
     fcachename = Symbol("##", f, "_memoized_cache")
     esc(quote
-        Base.empty!(eval($fcachename))
+        Base.empty!($fcachename)
     end)
 end
 

--- a/src/Memoize.jl
+++ b/src/Memoize.jl
@@ -76,4 +76,17 @@ macro memoize(args...)
     end)
 
 end
+
+macro clear_cache(f)
+    fcachename = Symbol("##", f, "_memoized_cache")
+    mod = __module__
+    fcache = getfield(mod, fcachename)
+
+    function clear_cache!(x::IdDict)
+        foreach(k -> delete!(fcache, k), keys(fcache))
+    end
+
+    Core.eval(mod, :($(clear_cache!(fcache))))
 end
+
+end # module

--- a/src/Memoize.jl
+++ b/src/Memoize.jl
@@ -78,9 +78,9 @@ macro memoize(args...)
 end
 
 macro clear_cache(f)
+    fcachename = Symbol("##", f, "_memoized_cache")
     esc(quote
-        fcachename = Symbol("##", $f, "_memoized_cache")
-        Base.empty!(eval(fcachename))
+        Base.empty!(eval($fcachename))
     end)
 end
 

--- a/src/Memoize.jl
+++ b/src/Memoize.jl
@@ -1,6 +1,6 @@
 module Memoize
 using MacroTools: isexpr, combinedef, namify, splitarg, splitdef
-export @memoize, @memoize_cache
+export @memoize, memoize_cache
 
 cache_name(f) = Symbol("##", f, "_memoized_cache")
 
@@ -79,17 +79,8 @@ macro memoize(args...)
 
 end
 
-function memoize_cache(m::Module, f::Function)
-    fmodulename = which(m, Symbol(f))
-    getproperty(fmodulename, cache_name(f))
+function memoize_cache(f::Function)
+    getproperty(parentmodule(f), cache_name(f))
 end
 
-macro memoize_cache(f)
-    m = __module__
-    f_symbol = :($f)
-    esc(quote
-        Memoize.memoize_cache($m, $f_symbol)
-    end)
 end
-
-end # module

--- a/src/Memoize.jl
+++ b/src/Memoize.jl
@@ -1,6 +1,6 @@
 module Memoize
 using MacroTools: isexpr, combinedef, namify, splitarg, splitdef
-export @memoize
+export @memoize, @clear_cache
 
 macro memoize(args...)
     if length(args) == 1
@@ -78,15 +78,10 @@ macro memoize(args...)
 end
 
 macro clear_cache(f)
-    fcachename = Symbol("##", f, "_memoized_cache")
-    mod = __module__
-    fcache = getfield(mod, fcachename)
-
-    function clear_cache!(x::IdDict)
-        foreach(k -> delete!(fcache, k), keys(fcache))
-    end
-
-    Core.eval(mod, :($(clear_cache!(fcache))))
+    esc(quote
+        fcachename = Symbol("##", $f, "_memoized_cache")
+        Base.empty!(eval(fcachename))
+    end)
 end
 
 end # module

--- a/src/Memoize.jl
+++ b/src/Memoize.jl
@@ -80,6 +80,9 @@ macro memoize(args...)
 end
 
 function memoize_cache(f::Function)
+    # This will fail in certain circumstances (eg. @memoize Base.sin(::MyNumberType) = ...) but I don't think there's 
+    # a clean answer here, because we can already have multiple caches for certain functions, if the methods are 
+    # defined in different modules.
     getproperty(parentmodule(f), cache_name(f))
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,10 @@ end
 @test simple(6) == 6
 @test run == 2
 
+Memoize.@clear_cache(simple)
+@test simple(6) == 6
+@test run == 3
+
 run = 0
 @memoize function typed(a::Int)
     global run += 1
@@ -333,3 +337,8 @@ end
 @test run == 2
 @test dict_call("bb") == 2
 @test run == 2
+
+run = 0
+@memoize function increase()
+    global run += 1
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,7 +29,7 @@ end
 @test simple(6) == 6
 @test run == 2
 
-empty!(@memoize_cache(simple))
+empty!(memoize_cache(simple))
 @test simple(6) == 6
 @test run == 3
 @test simple(6) == 6
@@ -328,13 +328,13 @@ end # module
 using .MemoizeTest
 using .MemoizeTest: custom_dict
 
-empty!(@memoize_cache(custom_dict))
+empty!(memoize_cache(custom_dict))
 @test custom_dict(1) == 1
 @test MemoizeTest.run == 3
 @test custom_dict(1) == 1
 @test MemoizeTest.run == 3
 
-empty!(@memoize_cache(MemoizeTest.custom_dict))
+empty!(memoize_cache(MemoizeTest.custom_dict))
 @test custom_dict(1) == 1
 @test MemoizeTest.run == 4
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,8 @@ end
 Memoize.@clear_cache(simple)
 @test simple(6) == 6
 @test run == 3
+@test simple(6) == 6
+@test run == 3
 
 run = 0
 @memoize function typed(a::Int)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,7 +29,7 @@ end
 @test simple(6) == 6
 @test run == 2
 
-Memoize.@clear_cache(simple)
+empty!(@memoize_cache(simple))
 @test simple(6) == 6
 @test run == 3
 @test simple(6) == 6
@@ -301,7 +301,6 @@ end
 @test vararg_func((1,1), (1,2)) == (1,1)
 @test run == 2
 
-
 module MemoizeTest
 using Test
 using Memoize
@@ -324,7 +323,20 @@ end
 @test custom_dict(1) == 1
 @test run == 2
 
-end
+end # module
+
+using .MemoizeTest
+using .MemoizeTest: custom_dict
+
+empty!(@memoize_cache(custom_dict))
+@test custom_dict(1) == 1
+@test MemoizeTest.run == 3
+@test custom_dict(1) == 1
+@test MemoizeTest.run == 3
+
+empty!(@memoize_cache(MemoizeTest.custom_dict))
+@test custom_dict(1) == 1
+@test MemoizeTest.run == 4
 
 run = 0
 @memoize Dict{Tuple{String},Int}() function dict_call(a::String)::Int
@@ -339,3 +351,4 @@ end
 @test run == 2
 @test dict_call("bb") == 2
 @test run == 2
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -337,8 +337,3 @@ end
 @test run == 2
 @test dict_call("bb") == 2
 @test run == 2
-
-run = 0
-@memoize function increase()
-    global run += 1
-end


### PR DESCRIPTION
This PR is an attempt to implement clearing of the cache (https://github.com/JuliaCollections/Memoize.jl/issues/14). 

EDIT: In a previous version of this comment, I stated that other types than `IdDict` needed to be considered. Since `Base.empty!` takes collections, I believe that the code should now work for any relevant type.