### PR TITLE
Document syntax-dependent behavior of `@memoize`, and assumptions about which methods are implemented for the supplied cache type

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,6 @@ using LRUCache
 end
 ```
 
-Note that the `@memoize` macro treats the type argument differently depending on its syntactical form: in the expression
-```julia
-@memoize CacheType function x(a, b)
-  # ...
-end
-```
-the expression `CacheType` must be either a non-function-call that evaluates to a type, or a function call that evaluates to an _instance_ of the desired cache type.  Either way, the methods `Base.get!` and `Base.empty!` must be defined for the supplied cache type.
-
 ```julia
 julia> x(1,2)
 Running
@@ -89,3 +81,13 @@ Running
 julia> x(2,3)
 5
 ```
+
+## Notes
+
+Note that the `@memoize` macro treats the type argument differently depending on its syntactical form: in the expression
+```julia
+@memoize CacheType function x(a, b)
+    # ...
+end
+```
+the expression `CacheType` must be either a non-function-call that evaluates to a type, or a function call that evaluates to an _instance_ of the desired cache type.  Either way, the methods `Base.get!` and `Base.empty!` must be defined for the supplied cache type.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ using LRUCache
 end
 ```
 
+Note that the `@memoize` macro treats the type argument differently depending on its syntactical form: in the expression
+```julia
+@memoize CacheType function x(a, b)
+  # ...
+end
+```
+the expression `CacheType` must be either a non-function-call that evaluates to a type, or a function call that evaluates to an _instance_ of the desired cache type.  Either way, the methods `Base.get!` and `Base.empty!` must be defined for the supplied cache type.
+
 ```julia
 julia> x(1,2)
 Running


### PR DESCRIPTION
Our code broke after https://github.com/JuliaCollections/Memoize.jl/pull/51.  The root cause was that we were using undocumented behavior of `@memoize` that changed after that PR, namely, we assumed `dicttype` was always treated as a function -- namely the constructor that, when called with no arguments, produces an instance of the desired cache type.  Specifically our code looked like:
```julia
function _LRUWithMaxSize(n::Integer)
    (args...; kwargs...) -> LRU(args...; maxsize=n, kwargs...)
end

@memoize _LRUWithMaxSize(10) function f(#= ... =#)
    # ...
end
```
and after the update to Memoize.jl it failed with the error
```
MethodError: no method matching empty!(::MyProject.var"#9#11"{MyProject.var"#9#10#12"{Int64}})
```
The issue was that before https://github.com/JuliaCollections/Memoize.jl/pull/51, the value of `dicttype` was always treated as a function, whereas after the PR, `@memoize` tries to guess whether `dicttype` already looks like a function call and behaves differently depending on what it guesses.  We fixed this easily by changing our code to
```julia
@memoize LRU(maxsize=10) function f(#= ... =#)
    # ...
end
```
but this non-uniform treatment of the cache type expression should definitely be documented.