### PR TITLE
Remove eval, memoize methodwise, traits, callables, typed caches

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ using Memoize
 end
 ```
 
-You can also specify the full expression for constructing the cache. The variables `__Key__` and `__Val__` are available to the constructor expression, containing the syntactically determined type bounds on the keys and values used by Memoize.jl.  For example, to use LRUCache.jl:
+You can also specify the full expression for constructing the cache. The variables `__Key__` and `__Value__` are available to the constructor expression, containing the syntactically determined type bounds on the keys and values used by Memoize.jl.  For example, to use LRUCache.jl:
 
 ```julia
 using Memoize
 using LRUCache
-@memoize LRU{__Key__,__Val__}(maxsize=2) function x(a, b)
+@memoize LRU{__Key__,__Value__}(maxsize=2) function x(a, b)
     println("Running")
     a + b
 end

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [ci-img]: https://github.com/JuliaCollections/Memoize.jl/workflows/CI/badge.svg
 [ci-url]: https://github.com/JuliaCollections/Memoize.jl/actions
 
-Easy memoization for Julia.
+Easy method memoization for Julia.
 
 ## Usage
 
@@ -23,15 +23,16 @@ julia> x(1)
 Running
 2
 
-julia> memoize_cache(x)
-IdDict{Any,Any} with 1 entry:
-  (1,) => 2
+julia> memories(x)
+1-element Array{Any,1}:
+ IdDict{Tuple{Any},Any}((1,) => 2)
 
 julia> x(1)
 2
 
-julia> empty!(memoize_cache(x))
-IdDict{Any,Any}()
+julia> map(empty!, memories(x))
+1-element Array{IdDict{Tuple{Any},Any},1}:
+ IdDict()
 
 julia> x(1)
 Running
@@ -41,22 +42,22 @@ julia> x(1)
 2
 ```
 
-By default, Memoize.jl uses an [`IdDict`](https://docs.julialang.org/en/v1/base/collections/#Base.IdDict) as a cache, but it's also possible to specify the type of the cache. If you want to cache vectors based on the values they contain, you probably want this:
+By default, Memoize.jl uses an [`IdDict`](https://docs.julialang.org/en/v1/base/collections/#Base.IdDict) as a cache, but it's also possible to specify your own cache that supports the methods `Base.get!` and `Base.empty!`. If you want to cache vectors based on the values they contain, you probably want this:
 
 ```julia
 using Memoize
-@memoize Dict function x(a)
+@memoize Dict() function x(a)
 	println("Running")
 	a
 end
 ```
 
-You can also specify the full function call for constructing the dictionary. For example, to use LRUCache.jl:
+You can also specify the full expression for constructing the cache. The variables `__Key__` and `__Val__` are available to the constructor expression, containing the syntactically determined type bounds on the keys and values used by Memoize.jl.  For example, to use LRUCache.jl:
 
 ```julia
 using Memoize
 using LRUCache
-@memoize LRU{Tuple{Any,Any},Any}(maxsize=2) function x(a, b)
+@memoize LRU{__Key__,__Val__}(maxsize=2) function x(a, b)
     println("Running")
     a + b
 end
@@ -86,12 +87,34 @@ julia> x(2,3)
 5
 ```
 
-## Notes
+Memoize works on *almost* every method declaration in global and local scope, including lambdas and callable objects. When only the type of an argument is given, memoize caches the type.
 
-Note that the `@memoize` macro treats the type argument differently depending on its syntactical form: in the expression
-```julia
-@memoize CacheType function x(a, b)
-    # ...
+julia```
+struct F{A}
+	a::A
+end
+@memoize function (::F{A})(b, ::C) where {A, C}
+	println("Running")
+	(A, b, C)
 end
 ```
-the expression `CacheType` must be either a non-function-call that evaluates to a type, or a function call that evaluates to an _instance_ of the desired cache type.  Either way, the methods `Base.get!` and `Base.empty!` must be defined for the supplied cache type.
+
+```
+julia> F(1)(1, 1)
+Running
+(Int64, 1, Int64)
+
+julia> F(1)(1, 2)
+(Int64, 1, Int64)
+
+julia> F(1)(2, 2)
+Running
+(Int64, 2, Int64)
+
+julia> F(2)(2, 2)
+(Int64, 2, Int64)
+
+julia> F(false)(2, 2)
+Running
+(Bool, 2, Int64)
+```

--- a/src/Memoize.jl
+++ b/src/Memoize.jl
@@ -51,7 +51,7 @@ macro memoize(args...)
         end
     end
 
-    fcachename = cache_name(f)
+    @gensym fcache
     mod = __module__
 
     body = quote
@@ -69,7 +69,9 @@ macro memoize(args...)
     end
 
     esc(quote
-        local $fcachename = $cache_dict  # see #48 comment for `local` explanation
+        # The `local` qualifier will make this performant even in the global scope.
+        local $fcache = $cache_dict
+        $(cache_name(f)) = $fcache   # for `memoize_cache(f)`
         $(combinedef(def_dict_unmemoized))
         Base.@__doc__ $(combinedef(def_dict))
     end)
@@ -77,9 +79,9 @@ macro memoize(args...)
 end
 
 function memoize_cache(f::Function)
-    # This will fail in certain circumstances (eg. @memoize Base.sin(::MyNumberType) = ...) but I don't think there's 
-    # a clean answer here, because we can already have multiple caches for certain functions, if the methods are 
-    # defined in different modules.
+    # This will fail in certain circumstances (eg. @memoize Base.sin(::MyNumberType) = ...) but I
+    # don't think there's a clean answer here, because we can already have multiple caches for
+    # certain functions, if the methods are defined in different modules.
     getproperty(parentmodule(f), cache_name(f))
 end
 

--- a/src/Memoize.jl
+++ b/src/Memoize.jl
@@ -86,7 +86,7 @@ macro memoize(args...)
     key_arg_types = [arg_sigs; kwarg_sigs]
 
     @gensym inner
-    inner_def = copy(def)
+    inner_def = deepcopy(def)
     inner_def[:name] = inner
     pop!(inner_def, :params, nothing)
 

--- a/src/Memoize.jl
+++ b/src/Memoize.jl
@@ -62,14 +62,6 @@ macro memoize(args...)
             return arg_type
         end
     end
-    kwarg_sigs = map(def[:args]) do arg
-        arg_name, arg_type, is_splat, default = splitarg(arg)
-        if is_splat
-            return :(Vararg{$arg_type})
-        else
-            return arg_type
-        end
-    end
 
     # Set up identity arguments to pass to unmemoized function
     pass_args = map(args) do arg

--- a/src/Memoize.jl
+++ b/src/Memoize.jl
@@ -69,6 +69,11 @@ macro memoize(args...)
     end
 
     esc(quote
+        try
+            empty!(memoize_cache($f))
+        catch
+        end
+
         # The `local` qualifier will make this performant even in the global scope.
         local $fcache = $cache_dict
         $(cache_name(f)) = $fcache   # for `memoize_cache(f)`

--- a/src/Memoize.jl
+++ b/src/Memoize.jl
@@ -70,6 +70,7 @@ macro memoize(args...)
 
     esc(quote
         try
+            # So that redefining a function doesn't leak memory through the previous cache.
             empty!(memoize_cache($f))
         catch
         end

--- a/src/Memoize.jl
+++ b/src/Memoize.jl
@@ -29,7 +29,7 @@ brain() = _brain
 """
 macro memoize(args...)
     if length(args) == 1
-        cache_constructor = :(IdDict{__Key__}{__Val__}())
+        cache_constructor = :(IdDict{__Key__}{__Value__}())
         ex = args[1]
     elseif length(args) == 2
         (cache_constructor, ex) = args
@@ -141,7 +141,7 @@ macro memoize(args...)
         # The `local` qualifier will make this performant even in the global scope.
         local $cache = begin
             local __Key__ = (Tuple{$(key_types...)} where {$(def[:whereparams]...)})
-            local __Val__ = ($return_type where {$(def[:whereparams]...)})
+            local __Value__ = ($return_type where {$(def[:whereparams]...)})
             $cache_constructor
         end
 

--- a/src/Memoize.jl
+++ b/src/Memoize.jl
@@ -127,7 +127,7 @@ macro memoize(args...)
 
     if length(kwargs) == 0
         def[:body] = quote
-            $(def[:body])::Core.Compiler.return_type($inner, typeof(($(pass_args...),)))
+            $(def[:body])::Core.Compiler.widenconst(Core.Compiler.return_type($inner, typeof(($(pass_args...),))))
         end
     end
 

--- a/src/Memoize.jl
+++ b/src/Memoize.jl
@@ -69,10 +69,8 @@ macro memoize(args...)
     end
 
     esc(quote
-        $fcachename = $cache_dict  # this should be `const` for performance, but then this
-                                   # fails the local-function cache test.
+        local $fcachename = $cache_dict  # see #48 comment for `local` explanation
         $(combinedef(def_dict_unmemoized))
-        empty!($fcachename)
         Base.@__doc__ $(combinedef(def_dict))
     end)
 

--- a/src/Memoize.jl
+++ b/src/Memoize.jl
@@ -145,7 +145,7 @@ macro memoize(args...)
     @gensym old_meth
     @gensym meth
 
-    res = esc(quote
+    esc(quote
         # The `local` qualifier will make this performant even in the global scope.
         local $cache = begin
             local __Key__ = (Tuple{$(key_arg_types...)} where {$(def[:whereparams]...)})
@@ -167,10 +167,9 @@ macro memoize(args...)
         local $meth = $_which($sig)
         @assert $meth !== nothing
         $brain()[$meth] = $cache
+
         $result
     end)
-    #println(res)
-    res
 end
 
 """

--- a/src/Memoize.jl
+++ b/src/Memoize.jl
@@ -107,14 +107,14 @@ macro memoize(args...)
     end
     key_types = map([inner_args; inner_kwargs]) do arg
         arg.trait ? DataType :
-        arg.vararg ? :(Tuple{$(arg.arg_type)}) : #TODO arg.slurp?
+        arg.vararg ? :(Tuple{$(arg.arg_type)}) :
             arg.arg_type
     end
 
     @gensym cache
 
-    pass_args = pass.(split.(inner_def[:args]))
-    pass_kwargs = pass.(split.(inner_def[:kwargs], true))
+    pass_args = pass.(inner_args)
+    pass_kwargs = pass.(inner_kwargs)
     def[:body] = quote
         $(combinedef(inner_def))
         get!($cache, ($(key_names...),)) do

--- a/src/Memoize.jl
+++ b/src/Memoize.jl
@@ -53,9 +53,6 @@ macro memoize(args...)
 
     fcachename = cache_name(f)
     mod = __module__
-    fcache = isdefined(mod, fcachename) ?
-             getfield(mod, fcachename) :
-             Core.eval(mod, :(const $fcachename = $cache_dict))
 
     body = quote
         get!($fcache, ($(tup...),)) do
@@ -72,8 +69,10 @@ macro memoize(args...)
     end
 
     esc(quote
+        $fcachename = $cache_dict  # this should be `const` for performance, but then this
+                                   # fails the local-function cache test.
         $(combinedef(def_dict_unmemoized))
-        empty!($fcache)
+        empty!($fcachename)
         Base.@__doc__ $(combinedef(def_dict))
     end)
 

--- a/src/Memoize.jl
+++ b/src/Memoize.jl
@@ -164,7 +164,7 @@ macro memoize(args...)
         
         # If overwriting a method, empty the old cache.
         local $old_meth = $_which($sig, $world)
-        if $old_meth !== nothing
+        if $old_meth !== nothing && $old_meth.sig == $sig
             empty!(pop!($brain(), $old_meth, []))
         end
 

--- a/src/Memoize.jl
+++ b/src/Memoize.jl
@@ -4,6 +4,13 @@ export @memoize, memoize_cache
 
 cache_name(f) = Symbol("##", f, "_memoized_cache")
 
+function try_empty_cache(f)
+    try
+        empty!(memoize_cache(f))
+    catch
+    end
+end
+
 macro memoize(args...)
     if length(args) == 1
         dicttype = :(IdDict)
@@ -69,12 +76,8 @@ macro memoize(args...)
     end
 
     esc(quote
-        try
-            # So that redefining a function doesn't leak memory through the previous cache.
-            empty!(memoize_cache($f))
-        catch
-        end
-
+        $Memoize.try_empty_cache($f) # So that redefining a function doesn't leak memory through
+                                     # the previous cache.
         # The `local` qualifier will make this performant even in the global scope.
         local $fcache = $cache_dict
         $(cache_name(f)) = $fcache   # for `memoize_cache(f)`

--- a/src/Memoize.jl
+++ b/src/Memoize.jl
@@ -132,6 +132,7 @@ macro memoize(args...)
     @gensym old_meth
     @gensym meth
     @gensym brain
+    @gensym old_brain
 
     sig = :(Tuple{$head, $(dispatch.(args)...)} where {$(def[:whereparams]...)})
 
@@ -157,7 +158,10 @@ macro memoize(args...)
         # Notice that methods are hashed by their stored signature
         local $old_meth = $_which($sig, $world)
         if $old_meth !== nothing && $old_meth.sig == $sig
-            empty!(pop!($brain, $old_meth.sig, []))
+            if isdefined($old_meth.module, :__Memoize_brain__)
+                $old_brain = getfield($old_meth.module, :__Memoize_brain__)
+                empty!(pop!($old_brain, $old_meth.sig, []))
+            end
         end
 
         # Store the cache so that it can be emptied later

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -269,7 +269,7 @@ end
 method_rewrite()
 @memoize function method_rewrite() end
 GC.gc()
-@test_broken finalized
+@test finalized
 
 run = 0
 """ documented function """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -333,6 +333,27 @@ end
 @test callable_trait_object(2)(3) == (Int, 3)
 @test run == 4
 
+run = 0
+struct callable_type{T}
+    a::T
+end
+@memoize function callable_type{T}(b) where {T}
+    global run += 1
+    (T, b)
+end
+@test callable_type{Int}(2) == (Int, 2)
+@test run == 1
+@test callable_type{Int}(2) == (Int, 2)
+@test run == 1
+@test callable_type{Int}(3) == (Int, 3)
+@test run == 2
+@test callable_type{Int}(3) == (Int, 3)
+@test run == 2
+@test callable_type{Bool}(3) == (Bool, 3)
+@test run == 3
+@test callable_type{Bool}(3) == (Bool, 3)
+@test run == 3
+
 @memoize function typeinf(x)
     x + 1
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,7 +29,7 @@ end
 @test simple(6) == 6
 @test run == 2
 
-empty!(memoize_cache(simple))
+map(empty!, function_memories(simple))
 @test simple(6) == 6
 @test run == 3
 @test simple(6) == 6
@@ -183,7 +183,7 @@ end
 @test run == 2
 
 run = 0
-@memoize Dict function kw_ellipsis(;a...)
+@memoize Dict() function kw_ellipsis(;a...)
     global run += 1
     a
 end
@@ -308,7 +308,7 @@ using Memoize
 const MyDict = Dict
 
 run = 0
-@memoize MyDict function custom_dict(a)
+@memoize MyDict() function custom_dict(a)
     global run += 1
     a
 end
@@ -328,13 +328,13 @@ end # module
 using .MemoizeTest
 using .MemoizeTest: custom_dict
 
-empty!(memoize_cache(custom_dict))
+map(empty!, function_memories(custom_dict))
 @test custom_dict(1) == 1
 @test MemoizeTest.run == 3
 @test custom_dict(1) == 1
 @test MemoizeTest.run == 3
 
-empty!(memoize_cache(MemoizeTest.custom_dict))
+map(empty!, function_memories(MemoizeTest.custom_dict))
 @test custom_dict(1) == 1
 @test MemoizeTest.run == 4
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -346,6 +346,9 @@ finalized = false
     x
 end
 method_rewrite()
+@memoize function method_rewrite(x) end
+GC.gc()
+@test !finalized
 @memoize function method_rewrite() end
 GC.gc()
 @test finalized

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,7 +29,7 @@ end
 @test simple(6) == 6
 @test run == 2
 
-map(empty!, function_memories(simple))
+map(empty!, memories(simple))
 @test simple(6) == 6
 @test run == 3
 @test simple(6) == 6
@@ -407,13 +407,13 @@ end # module
 using .MemoizeTest
 using .MemoizeTest: custom_dict
 
-map(empty!, function_memories(custom_dict))
+map(empty!, memories(custom_dict))
 @test custom_dict(1) == 1
 @test MemoizeTest.run == 3
 @test custom_dict(1) == 1
 @test MemoizeTest.run == 3
 
-map(empty!, function_memories(MemoizeTest.custom_dict))
+map(empty!, memories(MemoizeTest.custom_dict))
 @test custom_dict(1) == 1
 @test MemoizeTest.run == 4
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,26 @@ map(empty!, memories(simple))
 @test run == 3
 
 run = 0
+lambda = @memoize (a) -> begin
+    global run += 1
+    a
+end
+@test lambda(5) == 5
+@test run == 1
+@test lambda(5) == 5
+@test run == 1
+@test lambda(6) == 6
+@test run == 2
+@test lambda(6) == 6
+@test run == 2
+
+map(empty!, memories(lambda))
+@test lambda(6) == 6
+@test run == 3
+@test lambda(6) == 6
+@test run == 3
+
+run = 0
 @memoize function typed(a::Int)
     global run += 1
     a

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -269,7 +269,7 @@ end
 method_rewrite()
 @memoize function method_rewrite() end
 GC.gc()
-@test finalized
+@test_broken finalized
 
 run = 0
 """ documented function """
@@ -352,3 +352,5 @@ end
 @test dict_call("bb") == 2
 @test run == 2
 
+@memoize non_allocating(x) = x+1
+@test @allocated(non_allocating(10)) == 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -484,7 +484,21 @@ end
 @test dict_call("bb") == 2
 @test run == 2
 @test dict_call("bb") == 2
+
+run = 0
+@memoize Dict{__Key__,__Val__}() function auto_dict_call(a::String)::Int
+    global run += 1
+    length(a)
+end
+@test auto_dict_call("a") == 1
+@test run == 1
+@test auto_dict_call("a") == 1
+@test run == 1
+@test auto_dict_call("bb") == 2
 @test run == 2
+@test auto_dict_call("bb") == 2
+@test run == 2
+@test memories(auto_dict_call)[1] isa Dict{Tuple{String}, Int}
 
 @memoize non_allocating(x) = x+1
 @test @allocated(non_allocating(10)) == 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -254,6 +254,28 @@ end
 outer()
 @test !@isdefined inner
 
+
+run = 0
+struct callable_object
+    a
+end
+@memoize function (o::callable_object)(b)
+    global run += 1
+    (o.a, b)
+end
+@test callable_object(1)(2) == (1, 2)
+@test run == 1
+@test callable_object(1)(2) == (1, 2)
+@test run == 1
+@test callable_object(1)(3) == (1, 3)
+@test run == 2
+@test callable_object(1)(3) == (1, 3)
+@test run == 2
+@test callable_object(2)(3) == (2, 3)
+@test run == 3
+@test callable_object(2)(3) == (2, 3)
+@test run == 3
+
 @memoize function typeinf(x)
     x + 1
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -354,6 +354,37 @@ end
 @test callable_type{Bool}(3) == (Bool, 3)
 @test run == 3
 
+genrun = 0
+@memoize function genspec(a)
+    global genrun += 1
+    a + 1
+end
+specrun = 0
+@test genspec(5) == 6
+@test genrun == 1
+@test specrun == 0
+@memoize function genspec(a::Int)
+    global specrun += 1
+    a + 2
+end
+@test genspec(5) == 7
+@test genrun == 1
+@test specrun == 1
+@test genspec(5) == 7
+@test genrun == 1
+@test specrun == 1
+@test genspec(true) == 2
+@test genrun == 2
+@test specrun == 1
+@test invoke(genspec, Tuple{Any}, 5) == 6
+@test genrun == 2
+@test specrun == 1
+
+map(empty!, memories(genspec, Tuple{Int}))
+@test genspec(5) == 7
+@test genrun == 2
+@test specrun == 2
+
 @memoize function typeinf(x)
     x + 1
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -254,6 +254,42 @@ end
 outer()
 @test !@isdefined inner
 
+trait_function(a, ::Bool) = (-a,)
+run = 0
+@memoize function trait_function(a, ::Int)
+    global run += 1
+    (a,)
+end
+@test trait_function(1, true) == (-1,)
+@test run == 0
+@test trait_function(2, true) == (-2,)
+@test run == 0
+@test trait_function(1, 1) == (1,)
+@test run == 1
+@test trait_function(1, 2) == (1,)
+@test run == 1
+@test trait_function(2, 2) == (2,)
+@test run == 2
+@test trait_function(2, 2) == (2,)
+@test run == 2
+
+run = 0
+@memoize function trait_params(a, ::T) where {T}
+    global run += 1
+    (a, T)
+end
+@test trait_params(1, true) == (1, Bool)
+@test run == 1
+@test trait_params(1, false) == (1, Bool)
+@test run == 1
+@test trait_params(2, true) == (2, Bool)
+@test run == 2
+@test trait_params(2, false) == (2, Bool)
+@test run == 2
+@test trait_params(1, 3) == (1, Int)
+@test run == 3
+@test trait_params(1, 4) == (1, Int)
+@test run == 3
 
 run = 0
 struct callable_object
@@ -275,6 +311,27 @@ end
 @test run == 3
 @test callable_object(2)(3) == (2, 3)
 @test run == 3
+
+run = 0
+struct callable_trait_object{T}
+    a::T
+end
+@memoize function (::callable_trait_object{T})(b) where {T}
+    global run += 1
+    (T, b)
+end
+@test callable_trait_object(1)(2) == (Int, 2)
+@test run == 1
+@test callable_trait_object(2)(2) == (Int, 2)
+@test run == 1
+@test callable_trait_object(false)(2) == (Bool, 2)
+@test run == 2
+@test callable_trait_object(true)(3) == (Bool, 3)
+@test run == 3
+@test callable_trait_object(1)(3) == (Int, 3)
+@test run == 4
+@test callable_trait_object(2)(3) == (Int, 3)
+@test run == 4
 
 @memoize function typeinf(x)
     x + 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -506,7 +506,7 @@ end
 @test dict_call("bb") == 2
 
 run = 0
-@memoize Dict{__Key__,__Val__}() function auto_dict_call(a::String)::Int
+@memoize Dict{__Key__,__Value__}() function auto_dict_call(a::String)::Int
     global run += 1
     length(a)
 end


### PR DESCRIPTION
This PR picks up where #59 left off (thanks @cstjean for all your work on this repo!). If we remove `eval` and use one cache per method, then we need to be able to look up caches by their methods. Types can't be hashed by equivalence classes (otherwise I think Julia dispatch might be faster, consider `hash(Val{A} where {A}) != hash(Val{B} where B)`). Therefore, we need to use Julia's method lookup to find methods to find their cache. We use a global dictionary in the Memoize.jl module to map `Method` objects to their caches. Since this was already a big change, this PR also makes several related changes.

The key changes made by this PR
- Removes `eval`. (fixes #48)
- Caches are associated with methods, rather than functions. (fixes #66)
- Supports callable types, callable objects, and lambdas (Doesn't support inner constructors, I think)
- Supports trait memoization (i.e. arguments of the form `(::T)` can now be memoized, and they use `T` as their key)
- Removed syntactic special casing of dictionary construction, in favor of the simply supplying an expression which constructs the cache. (fixes #58)
- Defines local variables `__Key__` and `__Value__` in the cache constructor expression scope, to support more specific dictionary types.
- Only empties caches when methods are overwritten. (fixes #68)

In summary, now you can do:
```
struct F{A}
	a::A
end
@memoize Dict{__Key__, __Value__}() function (::F{A})(b, ::C) where {A, C}
	println("Running")
	(A, b, C)
end
```