### PR TITLE
Add support for method-wise cache invalidation.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ julia = "1.2"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Pkg"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/JuliaCollections/Memoize.jl.png?branch=master)](https://travis-ci.org/JuliaCollections/Memoize.jl) [![Coverage Status](https://coveralls.io/repos/github/JuliaCollections/Memoize.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaCollections/Memoize.jl?branch=master)
 
-Easy memoization for Julia.
+Easy method memoization for Julia.
 
 ## Usage
 
@@ -19,15 +19,16 @@ julia> x(1)
 Running
 2
 
-julia> memoize_cache(x)
-IdDict{Any,Any} with 1 entry:
-  (1,) => 2
+julia> memories(x)
+1-element Array{Any,1}:
+ IdDict{Any,Any}((1,) => 2)
 
 julia> x(1)
 2
 
-julia> empty!(memoize_cache(x))
-IdDict{Any,Any}()
+julia> map(empty!, memories(x))
+1-element Array{IdDict{Tuple{Any},Any},1}:
+ IdDict()
 
 julia> x(1)
 Running

--- a/src/Memoize.jl
+++ b/src/Memoize.jl
@@ -120,7 +120,6 @@ macro memoize(args...)
 
         $result
     end)
-
 end
 
 """
@@ -135,13 +134,8 @@ memories(f, args...) = _memories(methods(f, args...))
 function _memories(ms::Base.MethodList)
     memories = []
     for m in ms
-        if isdefined(m.module, :__Memoize_brain__)
-            brain = getfield(m.module, :__Memoize_brain__)
-            memory = get(brain, m.sig, nothing)
-            if memory !== nothing
-                push!(memories, memory)
-            end
-        end
+        cache = memory(m)
+        cache !== nothing && push!(memories, cache)
     end
     return memories
 end
@@ -156,6 +150,7 @@ function memory(m::Method)
         brain = getfield(m.module, :__Memoize_brain__)
         return get(brain, m.sig, nothing)
     end
+    return nothing
 end
 
 end

--- a/src/Memoize.jl
+++ b/src/Memoize.jl
@@ -97,10 +97,12 @@ macro memoize(args...)
         $(combinedef(def_dict_unmemoized))
         local $result = Base.@__doc__($(combinedef(def_dict)))
 
-        local $brain = if isdefined($__module__, :__Memoize_brain__)
-            brain = getfield($__module__, :__Memoize_brain__)
+        if isdefined($__module__, :__Memoize_brain__)
+            local $brain = $__module__.__Memoize_brain__
         else
             global __Memoize_brain__ = Dict()
+            local $brain = __Memoize_brain__
+            $__module__
         end
         
         # If overwriting a method, empty the old cache.
@@ -108,7 +110,7 @@ macro memoize(args...)
         local $old_meth = $_which($sig, $world)
         if $old_meth !== nothing && $old_meth.sig == $sig
             if isdefined($old_meth.module, :__Memoize_brain__)
-                $old_brain = getfield($old_meth.module, :__Memoize_brain__)
+                $old_brain = $old_meth.module.__Memoize_brain__
                 empty!(pop!($old_brain, $old_meth.sig, []))
             end
         end
@@ -147,7 +149,7 @@ end
 """
 function memory(m::Method)
     if isdefined(m.module, :__Memoize_brain__)
-        brain = getfield(m.module, :__Memoize_brain__)
+        brain = m.module.__Memoize_brain__
         return get(brain, m.sig, nothing)
     end
     return nothing

--- a/src/Memoize.jl
+++ b/src/Memoize.jl
@@ -1,7 +1,5 @@
 module Memoize
 using MacroTools: isexpr, combinedef, namify, splitarg, splitdef
-export @memoize, memoize_cache
-
 export @memoize, memories, memory
 
 # I would call which($sig) but it's only on 1.6 I think

--- a/test/TestPrecompile/Project.toml
+++ b/test/TestPrecompile/Project.toml
@@ -1,0 +1,7 @@
+name = "TestPrecompile"
+uuid = "ff0854c6-fbc5-40f0-bd2d-de277d7b8f28"
+authors = ["Peter Ahrens <ptrahrens@gmail.com>"]
+version = "0.1.0"
+
+[deps]
+Memoize = "c03570c3-d221-55d1-a50c-7939bbd78826"

--- a/test/TestPrecompile/src/TestPrecompile.jl
+++ b/test/TestPrecompile/src/TestPrecompile.jl
@@ -1,5 +1,10 @@
 module TestPrecompile
     using Memoize
-    @memoize forgetful(x) = true
-    forgetful(true)
+    run = 0
+    @memoize function forgetful(x)
+        global run += 1
+        return true
+    end
+        
+    forgetful(1)
 end # module

--- a/test/TestPrecompile/src/TestPrecompile.jl
+++ b/test/TestPrecompile/src/TestPrecompile.jl
@@ -1,0 +1,5 @@
+module TestPrecompile
+    using Memoize
+    @memoize forgetful(x) = true
+    forgetful(true)
+end # module

--- a/test/TestPrecompile2/Project.toml
+++ b/test/TestPrecompile2/Project.toml
@@ -1,0 +1,7 @@
+name = "TestPrecompile2"
+uuid = "7fd9c7c1-bae8-496a-aa66-4a9878cd045a"
+authors = ["Peter Ahrens <ptrahrens@gmail.com>"]
+version = "0.1.0"
+
+[deps]
+TestPrecompile = "ff0854c6-fbc5-40f0-bd2d-de277d7b8f28"

--- a/test/TestPrecompile2/src/TestPrecompile2.jl
+++ b/test/TestPrecompile2/src/TestPrecompile2.jl
@@ -1,0 +1,6 @@
+module TestPrecompile2
+
+using TestPrecompile
+TestPrecompile.forgetful(2)
+
+end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Memoize, Test
+using Memoize, Test, Pkg
 
 @test_throws LoadError eval(:(@memoize))
 @test_throws LoadError eval(:(@memoize () = ()))
@@ -368,6 +368,12 @@ map(empty!, memories(custom_dict))
 map(empty!, memories(MemoizeTest.custom_dict))
 @test custom_dict(1) == 1
 @test MemoizeTest.run == 4
+
+Pkg.activate(temp=true)
+Pkg.develop(path=joinpath(@__DIR__, "TestPrecompile"))
+using TestPrecompile
+
+@test length(memories(TestPrecompile.forgetful)) >= 1
 
 run = 0
 @memoize Dict{Tuple{String},Int}() function dict_call(a::String)::Int

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -373,6 +373,7 @@ Pkg.activate(temp=true)
 Pkg.develop(path=joinpath(@__DIR__, "TestPrecompile"))
 using TestPrecompile
 
+@test length(memories(TestPrecompile.forgetful)) == 1
 @test TestPrecompile.run == 1
 @test TestPrecompile.forgetful(1)
 @test TestPrecompile.run == 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -373,7 +373,16 @@ Pkg.activate(temp=true)
 Pkg.develop(path=joinpath(@__DIR__, "TestPrecompile"))
 using TestPrecompile
 
-@test length(memories(TestPrecompile.forgetful)) >= 1
+@test TestPrecompile.run == 1
+@test TestPrecompile.forgetful(1)
+@test TestPrecompile.run == 1
+
+Pkg.develop(path=joinpath(@__DIR__, "TestPrecompile2"))
+using TestPrecompile2
+
+@test TestPrecompile.run == 1
+@test TestPrecompile.forgetful(2)
+@test TestPrecompile.run == 2
 
 run = 0
 @memoize Dict{Tuple{String},Int}() function dict_call(a::String)::Int

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,7 +29,7 @@ end
 @test simple(6) == 6
 @test run == 2
 
-empty!(memoize_cache(simple))
+map(empty!, memories(simple))
 @test simple(6) == 6
 @test run == 3
 @test simple(6) == 6
@@ -254,6 +254,37 @@ end
 outer()
 @test !@isdefined inner
 
+genrun = 0
+@memoize function genspec(a)
+    global genrun += 1
+    a + 1
+end
+specrun = 0
+@test genspec(5) == 6
+@test genrun == 1
+@test specrun == 0
+@memoize function genspec(a::Int)
+    global specrun += 1
+    a + 2
+end
+@test genspec(5) == 7
+@test genrun == 1
+@test specrun == 1
+@test genspec(5) == 7
+@test genrun == 1
+@test specrun == 1
+@test genspec(true) == 2
+@test genrun == 2
+@test specrun == 1
+@test invoke(genspec, Tuple{Any}, 5) == 6
+@test genrun == 2
+@test specrun == 1
+
+map(empty!, memories(genspec, Tuple{Int}))
+@test genspec(5) == 7
+@test genrun == 2
+@test specrun == 2
+
 @memoize function typeinf(x)
     x + 1
 end
@@ -328,13 +359,13 @@ end # module
 using .MemoizeTest
 using .MemoizeTest: custom_dict
 
-empty!(memoize_cache(custom_dict))
+map(empty!, memories(custom_dict))
 @test custom_dict(1) == 1
 @test MemoizeTest.run == 3
 @test custom_dict(1) == 1
 @test MemoizeTest.run == 3
 
-empty!(memoize_cache(MemoizeTest.custom_dict))
+map(empty!, memories(MemoizeTest.custom_dict))
 @test custom_dict(1) == 1
 @test MemoizeTest.run == 4
 


### PR DESCRIPTION
As requested, part 1 of ? of my previous too-big PR. I believe this patch allows for precompilation-safe method-wise cache invalidation needed in #59. Cache lookup works as follows:

Use Julia's method lookup to find a method based on a target signature. Then look in the module the method was defined in for a global dictionary named `__memories__`. If the dictionary exists, then look for the method based on the structure of its signature, rather than the Method object itself (for some reason, it seems the the hash identity of the methods changes during precompilation).

We determine if we are overwriting a method by looking up the signature in an earlier world age because the function name we are looking for may not yet be defined. Note that finding a method with `which` is not enough to know we have overwritten the method: their signatures must be `==.`

I have tested the effects of precompilation manually, I'm not sure if there's a way to test for this automatically.